### PR TITLE
Update Skia library for Aseprite1.2.40

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -4,7 +4,7 @@ mkdir deps
 cd deps
 mkdir skia
 cd skia
-powershell -command "wget -UseBasicParsing -OutFile skia.zip https://github.com/aseprite/skia/releases/download/m96-2f1f21b8a9/Skia-Windows-Release-x64.zip"
+powershell -command "wget -UseBasicParsing -OutFile skia.zip https://github.com/aseprite/skia/releases/download/m102-861e4743af/Skia-Windows-Release-x64.zip"
 powershell -command "Expand-Archive -Path .\skia.zip -DestinationPath ."
 
 echo "switch to VS dev cmd"


### PR DESCRIPTION
Aseprite1.2.40 required  a compiled version of the aseprite-m102 branch of the Skia library ([see](https://github.com/aseprite/aseprite/blob/v1.2.40/INSTALL.md)) 
This fix this issue : #5 